### PR TITLE
Fix admin thumbnails

### DIFF
--- a/galleries/admin.py
+++ b/galleries/admin.py
@@ -49,10 +49,7 @@ class GalleryMembershipInline(GenericCollectionTabularInline):
     admin_thumbnail = AdminThumbnail('thumbnail')
 
     def thumbnail(self, obj):
-        if hasattr(obj, 'thumbnail'):
-            return self.admin_thumbnail_getter(obj.item) if obj.item else ''
-
-        return ''
+        return self.admin_thumbnail(obj.item) if obj.item else ''
 
 
 def create_gallery_membership_inline(membership_class):


### PR DESCRIPTION
This fixes the bug whereby admin thumbnails wouldn’t show up.

862821f added this check, but I’m not sure why as the membership model doesn’t have a thumbnail attribute.

I think this branch must never be visited anyway, since e545588 renamed the method it calls (but didn’t update the call), meaning that, if it were, we’d see AttributeErrors.